### PR TITLE
Fixed Example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import (
 
 func main() {
     // Create a limiter struct.
-    limiter := tollbooth.NewLimiter(1, time.Second, nil)
+    limiter := tollbooth.NewLimiter(1, nil)
 
     r := chi.NewRouter()
 


### PR DESCRIPTION
With the latest version of Chi (4.0.0) the example in the README.md produces the following error:

```
./main.go:107:33: too many arguments in call to tollbooth.NewLimiter
        have (number, time.Duration, nil)
        want (float64, *limiter.ExpirableOptions)
```

Removing the middle argument `time.Second` resolves this.