### PR TITLE
Bump didip/tollbooth to v6

### DIFF
--- a/tollbooth_chi.go
+++ b/tollbooth_chi.go
@@ -1,8 +1,8 @@
 package tollbooth_chi
 
 import (
-	"github.com/didip/tollbooth/v5"
-	"github.com/didip/tollbooth/v5/limiter"
+	"github.com/didip/tollbooth/v6"
+	"github.com/didip/tollbooth/v6/limiter"
 	"net/http"
 )
 


### PR DESCRIPTION
$subj. There is no versioning in this module but if you want to stick to another version of the tollbooth, you could stick to commit hash as a version so I don't think there will be any problems for users.