### PR TITLE
Fix tollbooth import to v8 in the Tollbooth v8 README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ import (
 	"net/http"
 
 	"github.com/didip/tollbooth/v8"
+	"github.com/didip/tollbooth/v8/limiter"
 	"github.com/pressly/chi"
 )
 
 func main() {
 	// Create a limiter struct.
-	limiter := tollbooth.NewLimiter(1, nil)
+	lmt := tollbooth.NewLimiter(1, nil)
 
 	r := chi.NewRouter()
 
@@ -30,7 +31,7 @@ func main() {
 	})
 
 	// Use HTTPMiddleware directly for easier integration with chi.
-	r.Use(tollbooth.HTTPMiddleware(limiter))
+	r.Use(tollbooth.HTTPMiddleware(lmt))
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, world!"))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/didip/tollbooth/v7"
+	"github.com/didip/tollbooth/v8"
 	"github.com/pressly/chi"
 )
 


### PR DESCRIPTION
Fixes the "With Tollbooth Version 8 and Higher" README example so it documents v8 correctly and compiles:

- import path `github.com/didip/tollbooth/v7` → `github.com/didip/tollbooth/v8` (it was in the v8 section)
- import the `github.com/didip/tollbooth/v8/limiter` package so `limiter.IPLookup` resolves
- rename the limiter variable to `lmt` so it no longer shadows the `limiter` package, making `lmt.SetIPLookup(...)` and `tollbooth.HTTPMiddleware(lmt)` refer to the right things

The "With Tollbooth version 7 and below" example is intentionally left on `/v7`. Follow-up to #10.